### PR TITLE
Document tscli 0.3/0.4 commands in the CLI reference

### DIFF
--- a/Tools/turbostackcli.md
+++ b/Tools/turbostackcli.md
@@ -31,7 +31,7 @@ The TSCLI tool uses levels of arguments to categorize functions. Every command s
 ### Firewall
 [!badge icon="rocket" text="tscli firewall check <ip>"] - Reports whether the IP is blocked, across both the Intrusion Prevention (IPS) layer (behavioral and manual blocks) and the firewall blocklist. Please make sure to only use valid IP addresses.
 
-[!badge icon="rocket" text="tscli firewall block <ip>"] - Adds a firewall rule to block a specific IP address as specified in the IP parameter. Blocks permanently by default; use the `--time <seconds>` option for a temporary block that auto-expires (for example `--time 86400` for 24 hours). Use the `--comment` option to add a comment. 
+[!badge icon="rocket" text="tscli firewall block <ip>"] - Adds a firewall rule to block a specific IP address as specified in the IP parameter. Blocks the IP for 30 days by default; use the `--time <seconds>` option for a different duration, or `--time -1` for a permanent block. Use the `--comment` option to add a comment. 
 
 [!badge icon="rocket" text="tscli firewall unblock <ip>"] - Removes the provided IP address from the firewall's deny list, and also clears any matching Intrusion Prevention (IPS) decision so it is not automatically re-blocked.
 

--- a/Tools/turbostackcli.md
+++ b/Tools/turbostackcli.md
@@ -29,11 +29,11 @@ The TSCLI tool uses levels of arguments to categorize functions. Every command s
 [!badge icon="rocket" text="tscli blackfire reload"] - Restarts the Blackfire Profiler service, to apply changes to the configuration.
 
 ### Firewall
-[!badge icon="rocket" text="tscli firewall check <ip>"] - Returns info on whether or not the IP parameter is listed in the iptables. Please make sure to only use valid IP addresses.
+[!badge icon="rocket" text="tscli firewall check <ip>"] - Reports whether the IP is blocked, across both the Intrusion Prevention (IPS) layer (behavioral and manual blocks) and the firewall blocklist. Please make sure to only use valid IP addresses.
 
-[!badge icon="rocket" text="tscli firewall block <ip>"] - Adds a firewall rule to block a specific IP address as specified in the IP parameter. Defaults to 24 hours, use `--time` option to specify duration, with -1 for permanent blocks. Use the `--comment` option to add a comment. 
+[!badge icon="rocket" text="tscli firewall block <ip>"] - Adds a firewall rule to block a specific IP address as specified in the IP parameter. Blocks permanently by default; use the `--time <seconds>` option for a temporary block that auto-expires (for example `--time 86400` for 24 hours). Use the `--comment` option to add a comment. 
 
-[!badge icon="rocket" text="tscli firewall unblock <ip>"] - Removes the provided IP address from the firewall's deny list.
+[!badge icon="rocket" text="tscli firewall unblock <ip>"] - Removes the provided IP address from the firewall's deny list, and also clears any matching Intrusion Prevention (IPS) decision so it is not automatically re-blocked.
 
 [!badge icon="rocket" text="tscli firewall display-blocks"] - Lists all active manual firewall blocks. Use `--full` to also get the automated blocks, we recommend piping the output to a file or a command-line text processing tool like grep or less.
 


### PR DESCRIPTION
Updates Tools/turbostackcli.md to cover newer tscli commands (sanitized example output, no host/customer specifics):

- Service Status (`tscli service status`) + per-service `status` subcommands
- Application Background Services (`tscli app status` / `list` / `backends`)
- Log Search (`tscli logs <source> <query>`, with `--explain`)
- Health Check (`tscli healthcheck [brief]`)
- Image Optimizer (`tscli tools image-optimizer`)
- `apache restart`, `firewall display-whitelists`, `rabbitmq status` + `queue list <vhost>` fix
- Firewall: block defaults to a 30-day block (`--time -1` for permanent); `check`/`unblock` now reflect the Intrusion Prevention (IPS) layer
